### PR TITLE
Fix CI python version, CI ansible version and latest galaxy import warnings

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -17,10 +17,10 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v2
     
-    - name: Set up Python 3.6
+    - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: 3.7
 
     - name: Install ansible-base (v${{ matrix.ansible }})
       run: pip install https://github.com/ansible/ansible/archive/v${{ matrix.ansible }}.tar.gz --disable-pip-version-check
@@ -43,10 +43,10 @@ jobs:
       matrix:
         ansible: [2.9.12, 2.10.0]
     steps:
-    - name: Set up Python 3.6
+    - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: 3.7
 
     - name: Install ansible-base (v${{ matrix.ansible }})
       run: pip install https://github.com/ansible/ansible/archive/v${{ matrix.ansible }}.tar.gz --disable-pip-version-check
@@ -84,10 +84,10 @@ jobs:
       matrix:
         ansible: [2.9.12, 2.10.0]
     steps:
-    - name: Set up Python 3.6
+    - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: 3.7
 
     - name: Install ansible-base (v${{ matrix.ansible }})
       run: pip install https://github.com/ansible/ansible/archive/v${{ matrix.ansible }}.tar.gz --disable-pip-version-check
@@ -105,7 +105,7 @@ jobs:
       run: ansible-galaxy collection install .cache/collection-tarballs/*.tar.gz
 
     # - name: Run unit tests
-    #   run: ansible-test units --docker -v --color --truncate 0 --python 3.6 --coverage
+    #   run: ansible-test units --docker -v --color --truncate 0 --python 3.7 --coverage
     #   working-directory: /home/runner/.ansible/collections/ansible_collections/cisco/nae
 
     # - name: Generate coverage report.
@@ -123,10 +123,10 @@ jobs:
     - build
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Python 3.6
+    - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: 3.7
 
     - name: Install ansible-base (v2.9.12)
       run: pip install https://github.com/ansible/ansible/archive/v2.9.12.tar.gz --disable-pip-version-check
@@ -151,8 +151,8 @@ jobs:
         timeout: 2000000
         interval: 5000
 
-    - name: Run integration tests on Python 3.6
-      run: ansible-test network-integration --docker -v --color --retry-on-error --python 3.6 --truncate 0 --continue-on-error --coverage
+    - name: Run integration tests on Python 3.7
+      run: ansible-test network-integration --docker -v --color --retry-on-error --python 3.7 --truncate 0 --continue-on-error --coverage
       working-directory: /home/runner/.ansible/collections/ansible_collections/cisco/nae
 
     - name: Releasing integration mutex

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ansible: [2.9.12, 2.10.0]
+        ansible: [2.9.16, 2.10.4]
     steps:
     - name: Check out code
       uses: actions/checkout@v2
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ansible: [2.9.12, 2.10.0]
+        ansible: [2.9.16, 2.10.4]
     steps:
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ansible: [2.9.12, 2.10.0]
+        ansible: [2.9.16, 2.10.4]
     steps:
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
@@ -128,8 +128,8 @@ jobs:
       with:
         python-version: 3.7
 
-    - name: Install ansible-base (v2.9.12)
-      run: pip install https://github.com/ansible/ansible/archive/v2.9.12.tar.gz --disable-pip-version-check
+    - name: Install ansible-base (v2.9.16)
+      run: pip install https://github.com/ansible/ansible/archive/v2.9.16.tar.gz --disable-pip-version-check
 
     - name: Install coverage (v4.5.4)
       run: pip install coverage==4.5.4

--- a/plugins/module_utils/nae.py
+++ b/plugins/module_utils/nae.py
@@ -34,7 +34,6 @@ __metaclass__ = type
 
 from requests_toolbelt.multipart.encoder import MultipartEncoder
 from datetime import datetime
-import base64
 import requests
 import csv
 import json
@@ -45,12 +44,8 @@ import gzip
 import filelock
 import pathlib
 import hashlib
-from copy import deepcopy
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.module_utils.urls import fetch_url
-from ansible.module_utils._text import to_bytes, to_native
-from jsonpath_ng import jsonpath, parse
+from jsonpath_ng import parse
 
 
 def nae_argument_spec():
@@ -399,8 +394,8 @@ class NAEModule(object):
 
     def is_json(self, myjson):
         try:
-            json_object = json.loads(myjson)
-        except ValueError as e:
+            json.loads(myjson)
+        except ValueError:
             return False
         return True
 
@@ -842,7 +837,6 @@ class NAEModule(object):
                     self.params['cmap'][attr['dn']] = existing_children
                 path = self.parse_path(attr['dn'])
                 cursor = tree
-                prev_node = None
                 curr_node_dn = ""
                 for node in path:
                     curr_node_dn += "/" + str(node)
@@ -869,7 +863,6 @@ class NAEModule(object):
                                 'children': {}
                             }
                     cursor = cursor['children'][node]
-                    prev_node = node
                 cursor['data'] = (nm, desc)
                 cursor['name'] = path[-1]
 
@@ -1033,7 +1026,6 @@ class NAEModule(object):
             self.module.fail_json(msg='Assurance group {0} does not exist'.format(self.params.get('ag_name')), **self.result)
         self.params['fabric_id'] = str(ag.get('uuid'))
         self.params['base_epoch_id'] = str(self.get_epochs()[0]["epoch_id"])
-        f = self.params.get('file')
         payload = {
             "name": self.params.get('name'),
             "fabric_uuid": self.params.get('fabric_id'),
@@ -1627,7 +1619,7 @@ class NAEModule(object):
                     self.module.fail_json(
                         'Failed to upload file chunks', **self.result)
             return file_upload_uuid
-        except Exception as e:
+        except Exception:
             self.module.fail_json(msg='Failed to upload file chunks', **self.result)
 
     def start_upload(self, uri, upload_type):
@@ -1717,7 +1709,7 @@ class NAEModule(object):
                 else:
                     self.module.fail_json(
                         msg="No response received while uploading chunks", **self.result)
-        except IOError as ioex:
+        except IOError:
             self.module.fail_json(
                 msg="Cannot open supplied file", **self.result)
         return None
@@ -1777,7 +1769,7 @@ class NAEModule(object):
 
             self.module.fail_json(msg="No upload complete", **self.result)
             raise Exception
-        except Exception as e:
+        except Exception:
             self.module.fail_json(msg="Unknown error", **self.result)
 
     def isLiveAnalysis(self):

--- a/plugins/modules/nae_ag.py
+++ b/plugins/modules/nae_ag.py
@@ -110,7 +110,6 @@ import requests
 
 def main():
     requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
-    result = dict(changed=False, resp='')
     argument_spec = nae_argument_spec()
     argument_spec.update(  # Not required for querying all objects
         name=dict(type='str', aliases=['fab_name']),
@@ -130,13 +129,9 @@ def main():
                            required_if=[['state', 'absent', ['name']],
                                         ['state', 'present', ['name']]])
 
-    description = module.params.get('description')
     state = module.params.get('state')
     name = module.params.get('name')
     online = module.params.get('online')
-    apic_hostname = module.params.get('apic_hostname')
-    apic_username = module.params.get('apic_username')
-    apic_password = module.params.get('apic_password')
     nae = NAEModule(module)
 
     if state == 'query' and name:

--- a/plugins/modules/nae_compliance.py
+++ b/plugins/modules/nae_compliance.py
@@ -96,7 +96,6 @@ import requests
 
 def main():
     requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
-    result = dict(changed=False, resp='')
     argument_spec = nae_argument_spec()
     argument_spec.update(  # Not required for querying all objects
         name=dict(type='str'),
@@ -117,12 +116,9 @@ def main():
                                         ['selector', 'requirement_set', ['ag_name']],
                                         ])
     selector = module.params.get('selector')
-    ag_name = module.params.get('ag_name')
     name = module.params.get('name')
     state = module.params.get('state')
     form = module.params.get('form')
-    association_to_ag = module.params.get('association_to_ag')
-    active = module.params.get('active')
     nae = NAEModule(module)
     if state == 'present' and form and selector == 'object':
         nae.new_object_selector()

--- a/plugins/modules/nae_delta.py
+++ b/plugins/modules/nae_delta.py
@@ -79,7 +79,6 @@ import requests
 
 def main():
     requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
-    result = dict(changed=False, resp='')
     argument_spec = nae_argument_spec()
     argument_spec.update(  # Not required for querying all objects
         validate_certs=dict(type='bool', default=False),
@@ -93,7 +92,6 @@ def main():
                            required_if=[['state', 'absent', ['ag_name', 'name']],
                                         ['state', 'query', ['ag_name']],
                                         ['state', 'present', ['ag_name', 'name']]])
-    ag_name = module.params.get('ag_name')
     name = module.params.get('name')
     state = module.params.get('state')
     nae = NAEModule(module)

--- a/plugins/modules/nae_file_management.py
+++ b/plugins/modules/nae_file_management.py
@@ -86,7 +86,6 @@ import requests
 
 def main():
     requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
-    result = dict(changed=False, resp='')
     argument_spec = nae_argument_spec()
     argument_spec.update(  # Not required for querying all objects
         name=dict(type='str', aliases=['unique_name']),
@@ -104,8 +103,6 @@ def main():
                                         ])
 
     state = module.params.get('state')
-    file_name = module.params.get('file')
-    name = module.params.get('name')
     nae = NAEModule(module)
 
     if state == 'present':

--- a/plugins/modules/nae_offline_analysis.py
+++ b/plugins/modules/nae_offline_analysis.py
@@ -87,7 +87,6 @@ import requests
 
 def main():
     requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
-    result = dict(changed=False, resp='')
     argument_spec = nae_argument_spec()
     argument_spec.update(  # Not required for querying all objects
         name=dict(type='str', aliases=['unique_name']),
@@ -108,9 +107,7 @@ def main():
                                         ])
 
     state = module.params.get('state')
-    file_name = module.params.get('file')
     name = module.params.get('name')
-    ag_name = module.params.get('ag_name')
     nae = NAEModule(module)
 
     if state == 'present':

--- a/plugins/modules/nae_prechange.py
+++ b/plugins/modules/nae_prechange.py
@@ -204,7 +204,6 @@ import requests
 
 def main():
     requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
-    result = dict(changed=False, resp='')
     argument_spec = nae_argument_spec()
     argument_spec.update(  # Not required for querying all objects
         ag_name=dict(type='str', aliases=['fab_name']),
@@ -227,9 +226,7 @@ def main():
 
     changes = module.params.get('changes')
     change_file = module.params.get('file')
-    description = module.params.get('description')
     state = module.params.get('state')
-    ag_name = module.params.get('ag_name')
     name = module.params.get('name')
     save = module.params.get('save')
     nae = NAEModule(module)

--- a/plugins/modules/nae_tcam.py
+++ b/plugins/modules/nae_tcam.py
@@ -68,7 +68,6 @@ import requests
 
 def main():
     requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
-    result = dict(changed=False, resp='')
     argument_spec = nae_argument_spec()
     argument_spec.update(  # Not required for querying all objects
         validate_certs=dict(type='bool', default=False),

--- a/tests/integration/inventory.networking
+++ b/tests/integration/inventory.networking
@@ -1,4 +1,4 @@
-localhost ansible_connection=local nae_host=173.36.219.125 validate_certs='no' nae_port=443 nae_username=ansible.github.ci nae_password=4C%269@RJKxdzneXpDd
+localhost nae_host=173.36.219.125 validate_certs='no' nae_port=443 nae_username=ansible.github.ci nae_password=4C%269@RJKxdzneXpDd
 [nae]
 localhost
 
@@ -6,3 +6,5 @@ localhost
 apic_hostname=173.36.219.25
 apic_username=ansible_github_ci
 apic_password="sJ94G92#8dq2hx*K4qh"
+ansible_connection=local
+ansible_python_interpreter=/usr/bin/python3.7

--- a/tests/integration/network-integration.requirements.txt
+++ b/tests/integration/network-integration.requirements.txt
@@ -1,4 +1,4 @@
-requests_toolbelt
+requests-toolbelt
 requests
 jsonpath_ng 
 pathlib 

--- a/tests/sanity/requirements.txt
+++ b/tests/sanity/requirements.txt
@@ -1,4 +1,3 @@
-requests_toolbelt
 requests-toolbelt
 requests
 jsonpath_ng 


### PR DESCRIPTION
- Fix requirements, inventory and CI config to move CI testing to Python 3.7
- Bump ansible version used in CI to 2.9.16 and 2.10.4
- Fix latest galaxy import warnings

Resolves #45 
Resolves #21 